### PR TITLE
Explicitly set AppConfig.default_auto_field 

### DIFF
--- a/django_coturn/apps.py
+++ b/django_coturn/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class DjangoCoturnConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
     name = "django_coturn"
 
     def ready(self):


### PR DESCRIPTION
Avoids ambiguity in support for Django 3.1 and 3.2 
https://docs.djangoproject.com/en/3.2/releases/3.2/\#customizing-type-of-auto-created-primary-keys